### PR TITLE
Avoid crash on malformed json.

### DIFF
--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -12,7 +12,11 @@ function call(broker, args, done) {
 	let payload;
 	console.log(args);
 	if (typeof(args.jsonParams) == "string")
-		payload = JSON.parse(args.jsonParams);
+		try {
+			payload = JSON.parse(args.jsonParams);
+		} catch(e) {
+			payload = args.jsonParams; // broker.call validator will handle this.
+		}
 	else {
 		payload = convertArgs(args.options);
 		if (args.options.save)

--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -14,8 +14,11 @@ function call(broker, args, done) {
 	if (typeof(args.jsonParams) == "string")
 		try {
 			payload = JSON.parse(args.jsonParams);
-		} catch(e) {
-			payload = args.jsonParams; // broker.call validator will handle this.
+		} catch(err) {
+			console.error(chalk.red.bold(">> ERROR:", err.message));
+			console.error(chalk.red.bold(err.stack));
+			done();
+			return;
 		}
 	else {
 		payload = convertArgs(args.options);


### PR DESCRIPTION
Avoid crash repl on malformed json.

Is we just pass the string direct after a unsuccessful parser the fastest-validator will handle properly.