### PR TITLE
Add JSON error checking to call action

### DIFF
--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -16,6 +16,7 @@ function call(broker, args, done) {
 			payload = JSON.parse(args.jsonParams);
 		} catch(e) {
 			console.log(chalk.red(">> Invalid JSON:", e.message));
+			return
 		}
 	else {
 		payload = convertArgs(args.options);

--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -12,7 +12,11 @@ function call(broker, args, done) {
 	let payload;
 	console.log(args);
 	if (typeof(args.jsonParams) == "string")
-		payload = JSON.parse(args.jsonParams);
+		try {
+			payload = JSON.parse(args.jsonParams);
+		} catch(e) {
+			console.log(chalk.red(">> Invalid JSON:", e.message));
+		}
 	else {
 		payload = convertArgs(args.options);
 		if (args.options.save)

--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -16,6 +16,7 @@ function call(broker, args, done) {
 			payload = JSON.parse(args.jsonParams);
 		} catch(e) {
 			console.log(chalk.red(">> Invalid JSON:", e.message));
+			done();
 			return
 		}
 	else {


### PR DESCRIPTION
 - Will log error to console and return from call instead of crashing when the call method is used with invalid json parameters.