### PR TITLE
Fix premature callback call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,12 @@
 
 require("v8"); // Load first. It won't work in `info.js`
 
-const _ = require("lodash");
-const vorpal = require("@moleculer/vorpal")();
-const { table, getBorderCharacters } = require("table");
-const chalk = require("chalk");
-const ora = require("ora");
-const clui = require("clui");
+const _ 				= require("lodash");
+const vorpal 			= require("@moleculer/vorpal")();
+const { table, getBorderCharacters } 	= require("table");
+const chalk 			= require("chalk");
+const ora 				= require("ora");
+const clui 				= require("clui");
 
 const registerCommands = require("./commands");
 
@@ -34,7 +34,7 @@ function REPL(broker, opts) {
 		delimiter: "mol $"
 	});
 
-	vorpal.removeIfExist = function (command) {
+	vorpal.removeIfExist = function(command) {
 		const cmd = vorpal.find(command);
 		if (cmd)
 			cmd.remove();

--- a/src/index.js
+++ b/src/index.js
@@ -9,14 +9,14 @@
 
 require("v8"); // Load first. It won't work in `info.js`
 
-const _ 				= require("lodash");
-const vorpal 			= require("@moleculer/vorpal")();
-const { table, getBorderCharacters } 	= require("table");
-const chalk 			= require("chalk");
-const ora 				= require("ora");
-const clui 				= require("clui");
+const _ = require("lodash");
+const vorpal = require("@moleculer/vorpal")();
+const { table, getBorderCharacters } = require("table");
+const chalk = require("chalk");
+const ora = require("ora");
+const clui = require("clui");
 
-const registerCommands 	= require("./commands");
+const registerCommands = require("./commands");
 
 /**
  * Start REPL mode
@@ -34,7 +34,7 @@ function REPL(broker, opts) {
 		delimiter: "mol $"
 	});
 
-	vorpal.removeIfExist = function(command) {
+	vorpal.removeIfExist = function (command) {
 		const cmd = vorpal.find(command);
 		if (cmd)
 			cmd.remove();
@@ -56,8 +56,10 @@ function REPL(broker, opts) {
 		.alias("quit")
 		.alias("exit")
 		.action((args, done) => {
-			broker.stop().then(() => process.exit(0));
-			done();
+			broker.stop().then(() => {
+				process.exit(0);
+				done();
+			});
 		});
 
 	// Register general commands

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const chalk 			= require("chalk");
 const ora 				= require("ora");
 const clui 				= require("clui");
 
-const registerCommands = require("./commands");
+const registerCommands 	= require("./commands");
 
 /**
  * Start REPL mode


### PR DESCRIPTION
In v0.6.0 calling `exit` command prematurely called the callback, which caused an error:
![image](https://user-images.githubusercontent.com/9802754/65374434-b2ca3900-dc81-11e9-9973-8609358ce913.png)

This PR solves the issue.