### PR TITLE
Fix RegexCache utilization

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -66,7 +66,8 @@ function match(text, pattern) {
 	}
 
 	// Regex (eg. "prefix.ab?cd.*.foo")
-	let regex = RegexCache.get(pattern);
+	const origPattern = pattern;
+	let regex = RegexCache.get(origPattern);
 	if (regex == null) {
 		if (pattern.startsWith("$")) {
 			pattern = "\\" + pattern;
@@ -79,8 +80,8 @@ function match(text, pattern) {
 		pattern = "^" + pattern + "$";
 
 		// eslint-disable-next-line security/detect-non-literal-regexp
-		regex = new RegExp(pattern, "g");
-		RegexCache.set(pattern, regex);
+		regex = new RegExp(pattern, "");
+		RegexCache.set(origPattern, regex);
 	}
 	return regex.test(text);
 }


### PR DESCRIPTION
Addresses the same issue seen in same utility function originally brought up in moleculerjs/moleculer#560.
Additionally, removed `g`, `global` option in RegExp constructor as this was done in the commit which resolved the above issue.