### PR TITLE
Returning Vorpal from constructor for better customization of the CLI // Autocomplete for dcall

### DIFF
--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -134,6 +134,11 @@ module.exports = function(vorpal, broker) {
 	vorpal
 		.removeIfExist("dcall")
 		.command("dcall <nodeID> <actionName> [jsonParams] [meta]", "Direct call an action")
+		.autocomplete({
+			data() {
+				return _.uniq(_.compact(broker.registry.getNodeList({ onlyAvailable: false, withServices: true }).map(node => node && node.id)));
+			}
+		})
 		.option("--load [filename]", "Load params from file")
 		.option("--stream [filename]", "Send a file as stream")
 		.option("--save [filename]", "Save response to file")

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ function REPL(broker, opts) {
 	}
 
 	// Start REPL
-	vorpal
+	return vorpal
 		.delimiter(opts.delimiter)
 		.show();
 


### PR DESCRIPTION
Very basic PR:

To make sure that we can make a great CLI/Repl under moleculer-repl, return the vorpal object is needed to improve the Repl customization.

Example:
```javascript
broker.start().then(() => {
	const repl = REPL(broker, {
					delimiter: "moleculer λ",
					customCommands: broker.options.replCommands
					});
	repl.removeIfExist("load");
	repl.removeIfExist("loadFolder");
});
```

Also: Autocomplete for dcall