### PR TITLE
add --loadFull to call command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -473,6 +473,12 @@
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
         },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
         "js-yaml": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -961,12 +967,6 @@
           }
         }
       }
-    },
-    "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -1731,15 +1731,6 @@
         "once": "^1.4.0"
       }
     },
-    "enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^4.1.1"
-      }
-    },
     "es5-ext": {
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
@@ -1906,9 +1897,9 @@
       }
     },
     "eslint": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-      "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
+      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.0.5",
@@ -1918,11 +1909,10 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.1.0",
+        "eslint-visitor-keys": "^3.2.0",
         "espree": "^9.3.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
@@ -1931,7 +1921,7 @@
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.6.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
@@ -1942,9 +1932,7 @@
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "progress": "^2.0.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.2.1",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
@@ -2005,9 +1993,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
       "dev": true
     },
     "espree": {
@@ -2019,14 +2007,6 @@
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^3.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -2411,9 +2391,9 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
     "ignore-by-default": {
@@ -3862,12 +3842,6 @@
           "dev": true
         }
       }
-    },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
     },
     "prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "MoleculerJS",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^8.6.0",
+    "eslint": "^8.7.0",
     "jest": "^27.4.7",
     "moleculer": "^0.14.19",
     "nodemon": "^2.0.7"

--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -71,6 +71,27 @@ async function handler(broker, args) {
 		}
 	}
 
+	// Load payload from file with a { "params" : {...}, "meta": {...}, options {...}} format
+	if (args.options.loadFull) {
+		let fName;
+		if (_.isString(args.options.loadFull)) {
+			fName = path.resolve(args.options.loadFull);
+		} else {
+			fName = path.resolve(`${args.actionName}.params.json`);
+		}
+		if (fs.existsSync(fName)) {
+			console.log(kleur.magenta(`>> Load params from '${fName}' file.`));
+			({
+				params: payload,
+				meta,
+				options: callOpts,
+			} = JSON.parse(fs.readFileSync(fName, "utf8")));
+			console.log(payload);
+		} else {
+			console.log(kleur.red(">> File not found:", fName));
+		}
+	}
+
 	// Load payload from file as stream
 	if (args.options.stream) {
 		let fName;
@@ -184,6 +205,10 @@ function declaration(program, broker, cmdHandler) {
 		.command("call <actionName> [jsonParams] [meta]")
 		.description("Call an action")
 		.option("--load [filename]", "Load params from file")
+		.option(
+			"--loadFull [filename]",
+			'Load params and meta from file (e.g., {"params":{}, "meta":{}, "options":{}})'
+		)
 		.option("--stream [filename]", "Send a file as stream")
 		.option("--save [filename]", "Save response to file")
 		.allowUnknownOption(true)
@@ -220,6 +245,10 @@ function declaration(program, broker, cmdHandler) {
 		.command("dcall <nodeID> <actionName> [jsonParams] [meta]")
 		.description("Direct call an action")
 		.option("--load [filename]", "Load params from file")
+		.option(
+			"--loadFull [filename]",
+			'Load params and meta from file (e.g., {"params":{}, "meta":{}, "options":{}})'
+		)
 		.option("--stream [filename]", "Send a file as stream")
 		.option("--save [filename]", "Save response to file")
 		.allowUnknownOption(true)

--- a/test/call.spec.js
+++ b/test/call.spec.js
@@ -137,7 +137,7 @@ describe("Test 'call' command", () => {
 	});
 
 	it("should call 'call' flags", async () => {
-		const command = `call "math.add" --load my-params.json --stream my-picture.jpg --save my-response.json`;
+		const command = `call "math.add" --load my-params.json --stream my-picture.jpg --save my-response.json --loadFull params.json`;
 
 		await program.parseAsync(
 			parseArgsStringToArgv(command, "node", "REPL")
@@ -149,10 +149,11 @@ describe("Test 'call' command", () => {
 				load: "my-params.json",
 				stream: "my-picture.jpg",
 				save: "my-response.json",
+				loadFull: "params.json",
 			},
 			actionName: "math.add",
 			rawCommand:
-				"call math.add --load my-params.json --stream my-picture.jpg --save my-response.json",
+				"call math.add --load my-params.json --stream my-picture.jpg --save my-response.json --loadFull params.json",
 		});
 	});
 });
@@ -294,7 +295,7 @@ describe("Test 'dcall' command", () => {
 	});
 
 	it("should call 'dcall' flags", async () => {
-		const command = `dcall node123 "math.add" --load my-params.json --stream my-picture.jpg --save my-response.json`;
+		const command = `dcall node123 "math.add" --load my-params.json --stream my-picture.jpg --save my-response.json --loadFull params.json`;
 
 		await program.parseAsync(
 			parseArgsStringToArgv(command, "node", "REPL")
@@ -306,11 +307,12 @@ describe("Test 'dcall' command", () => {
 				load: "my-params.json",
 				stream: "my-picture.jpg",
 				save: "my-response.json",
+				loadFull: "params.json",
 			},
 			actionName: "math.add",
 			nodeID: "node123",
 			rawCommand:
-				"dcall node123 math.add --load my-params.json --stream my-picture.jpg --save my-response.json",
+				"dcall node123 math.add --load my-params.json --stream my-picture.jpg --save my-response.json --loadFull params.json",
 		});
 	});
 });


### PR DESCRIPTION
Adds `--loadFull` flag to `call` command. This allows to load from file `params`, `meta` and `options`. Addresses https://github.com/moleculerjs/moleculer-repl/issues/41#issuecomment-832403567

File example:
```js
{
   "params": { "a": 1 },
   "meta": { "b": 2 },
   "options": { "timeout": 2 }
}
```