### PR TITLE
Adds `--local` opt to `call` cmd

### DIFF
--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -137,8 +137,8 @@ async function handler(broker, args) {
 		isStream(payload) ? "" : payload,
 		meta ? kleur.yellow().bold("with meta:") : "",
 		meta ? meta : "",
-		callOpts ? kleur.yellow().bold("with options:") : "",
-		callOpts ? callOpts : ""
+		Object.keys(callOpts).length ? kleur.yellow().bold("with options:") : "",
+		Object.keys(callOpts).length ? callOpts : ""
 	);
 
 	try {

--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -209,7 +209,7 @@ function declaration(program, broker, cmdHandler) {
 			"--loadFull [filename]",
 			'Load params and meta from file (e.g., {"params":{}, "meta":{}, "options":{}})'
 		)
-		.option("--local", "Call the local service broker")
+		.option("--$local", "Call the local service broker")
 		.option("--stream [filename]", "Send a file as stream")
 		.option("--save [filename]", "Save response to file")
 		.allowUnknownOption(true)
@@ -229,7 +229,7 @@ function declaration(program, broker, cmdHandler) {
 			thisCommand.params = {
 				options: parsedArgs,
 				actionName,
-        nodeID: parsedArgs.local ? broker.nodeID : undefined,
+				nodeID: parsedArgs.$local ? broker.nodeID : undefined,
 				...(jsonParams !== undefined ? { jsonParams } : undefined),
 				rawCommand,
 			};

--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -108,6 +108,20 @@ async function handler(broker, args) {
 		}
 	}
 
+	// Remove non-standard call opts
+	const nonStandardCallOpts = [{
+		key: "local",
+		replaceKey: "nodeID",
+		value: args.nodeID,
+	}];
+	for (let key of Object.keys(callOpts)) {
+		const opt = nonStandardCallOpts.find(opt => opt.key === key);
+		if (opt) {
+			delete callOpts[key];
+			opt.replaceKey ? callOpts[opt.replaceKey] = opt.value : undefined;
+		}
+	}
+
 	const startTime = process.hrtime();
 	const nodeID = args.nodeID;
 	meta.$repl = true;

--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -209,6 +209,7 @@ function declaration(program, broker, cmdHandler) {
 			"--loadFull [filename]",
 			'Load params and meta from file (e.g., {"params":{}, "meta":{}, "options":{}})'
 		)
+		.option("--local", "Call the local service broker")
 		.option("--stream [filename]", "Send a file as stream")
 		.option("--save [filename]", "Save response to file")
 		.allowUnknownOption(true)
@@ -228,6 +229,7 @@ function declaration(program, broker, cmdHandler) {
 			thisCommand.params = {
 				options: parsedArgs,
 				actionName,
+        nodeID: parsedArgs.local ? broker.nodeID : undefined,
 				...(jsonParams !== undefined ? { jsonParams } : undefined),
 				rawCommand,
 			};

--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -109,18 +109,16 @@ async function handler(broker, args) {
 	}
 
 	// Remove non-standard call opts
-	const nonStandardCallOpts = [{
+	[{
 		key: "local",
 		replaceKey: "nodeID",
 		value: args.nodeID,
-	}];
-	for (let key of Object.keys(callOpts)) {
-		const opt = nonStandardCallOpts.find(opt => opt.key === key);
-		if (opt) {
-			delete callOpts[key];
+	}].forEach(opt => {
+		if (callOpts[opt.key]) {
+			delete callOpts[opt.key];
 			opt.replaceKey ? callOpts[opt.replaceKey] = opt.value : undefined;
 		}
-	}
+	});
 
 	const startTime = process.hrtime();
 	const nodeID = args.nodeID;

--- a/test/call.spec.js
+++ b/test/call.spec.js
@@ -156,6 +156,29 @@ describe("Test 'call' command", () => {
 				"call math.add --load my-params.json --stream my-picture.jpg --save my-response.json --loadFull params.json",
 		});
 	});
+
+	it("should call 'call' targeting local broker", async () => {
+		const command = `call "math.add" --local --load my-params.json --stream my-picture.jpg --save my-response.json --loadFull params.json`;
+
+		await program.parseAsync(
+			parseArgsStringToArgv(command, "node", "REPL")
+		);
+
+		expect(cmdHandler).toHaveBeenCalledTimes(1);
+		expect(cmdHandler).toHaveBeenCalledWith(expect.any(ServiceBroker), {
+			options: {
+				local: true,
+				load: "my-params.json",
+				stream: "my-picture.jpg",
+				save: "my-response.json",
+				loadFull: "params.json",
+			},
+			actionName: "math.add",
+			nodeID: broker.nodeID,
+			rawCommand:
+				"call math.add --local --load my-params.json --stream my-picture.jpg --save my-response.json --loadFull params.json",
+		});
+	});
 });
 
 describe("Test 'dcall' command", () => {

--- a/test/call.spec.js
+++ b/test/call.spec.js
@@ -158,7 +158,7 @@ describe("Test 'call' command", () => {
 	});
 
 	it("should call 'call' targeting local broker", async () => {
-		const command = `call "math.add" --local --load my-params.json --stream my-picture.jpg --save my-response.json --loadFull params.json`;
+		const command = `call "math.add" --$local --load my-params.json --stream my-picture.jpg --save my-response.json --loadFull params.json`;
 
 		await program.parseAsync(
 			parseArgsStringToArgv(command, "node", "REPL")
@@ -167,7 +167,7 @@ describe("Test 'call' command", () => {
 		expect(cmdHandler).toHaveBeenCalledTimes(1);
 		expect(cmdHandler).toHaveBeenCalledWith(expect.any(ServiceBroker), {
 			options: {
-				local: true,
+				$local: true,
 				load: "my-params.json",
 				stream: "my-picture.jpg",
 				save: "my-response.json",
@@ -176,7 +176,7 @@ describe("Test 'call' command", () => {
 			actionName: "math.add",
 			nodeID: broker.nodeID,
 			rawCommand:
-				"call math.add --local --load my-params.json --stream my-picture.jpg --save my-response.json --loadFull params.json",
+				"call math.add --$local --load my-params.json --stream my-picture.jpg --save my-response.json --loadFull params.json",
 		});
 	});
 });


### PR DESCRIPTION
Addresses #65 

- new option `--local` can be used to target the local service broker (in use for REPL) similar to `dcall` but without providing a specific service broker ID
- adds unit test for new `--local` option to the tests for the `call` command

Creating this PR as a draft because during implementation it occurred to me that any options added to `call`/`dcall` commands fundamentally prevent use of those options for simple action parameter passing; i.e. `call v1.test.actionWithLocalParam --local` would both assume the caller wanted to call the action `v1.test.actionWithLocalParam` on the local service broker node event though they may have intended to call the action on a remote node but with a payload of `{ "local": true }`.

I have mixed feelings about this; on one hand this may rarely be an issue for anyone but on the other hand this could be a very inconvenient opinionation. It's somewhat similar to the con I described in the issue for detecting "local" as a valid node name as this could in rare circumstances be interesting if someone has a node in the system actually called "local".

Let me know what you think and I can make the necessary changes (or close the PR pending a better option). Thanks!