### PR TITLE
Feature - Multiple REPL with Remote REPL support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,12 +13,24 @@
 		{
 			"type": "node",
 			"request": "launch",
-			"name": "Launch demo",
+			"name": "Launch Demo - Simple",
 			"program": "${workspaceRoot}/examples/index.js",
 			"cwd": "${workspaceRoot}",
 			"args": [
 				"simple"
-			]
+			],
+			"console": "integratedTerminal"
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Launch Demo - Remote",
+			"program": "${workspaceRoot}/examples/index.js",
+			"cwd": "${workspaceRoot}",
+			"args": [
+				"remote"
+			],
+			"console": "integratedTerminal"
 		},
 		{
 			"type": "node",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="0.7.4"></a>
+# 0.7.4 (2022-11-16)
+
+## Changes
+- add support for instanting a remote REPL instance over TCP socket
+
 <a name="0.7.3"></a>
 # 0.7.3 (2022-10-06)
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ mol $
 **Start broker in REPL mode in a remote machine**
 ```js
 const broker = new ServiceBroker({
-	nodeID: "repl-" + process.pid,
-
+    ...
 	// REPL TCP Socket port
 	replTcpPort: 1337,
+    ...
 });
 
 broker.start().then(() => {

--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ You will get a console:
 mol $ 
 ```
 
+**Start broker in REPL mode in a remote machine**
+```js
+const broker = new ServiceBroker({
+	nodeID: "repl-" + process.pid,
+
+	// REPL TCP Socket port
+	replTcpPort: 1337,
+});
+
+broker.start().then(() => {
+    // Start REPL
+    broker.repl();
+});
+```
+
+On your local machine:
+
+```bash
+$ telnet <remote-machine-ip> 1337
+Trying <remote-machine-ip>...
+Connected to <remote-machine-ip>.
+Escape character is '^]'.
+mol $ 
+```
+
 Run `help` to see available commands.
 
 ## Documentation

--- a/examples/remote/index.js
+++ b/examples/remote/index.js
@@ -1,0 +1,130 @@
+"use strict";
+
+const { ServiceBroker } = require("moleculer");
+const REPL = require("../../src");
+
+// Create broker
+const broker = new ServiceBroker({
+	nodeID: "repl-" + process.pid,
+
+	// REPL TCP Socket port
+	replTcpPort: 5001,
+
+	// Custom REPL command
+	replCommands: [
+		{
+			command: "hello <name>",
+			description: "Call the greeter.hello service with name",
+			alias: "hi",
+			options: [
+				{
+					option: "-u, --uppercase",
+					description: "Uppercase the name",
+				},
+				{
+					option: "-p, --prefix <prefix>",
+					description: "Add prefix to the name",
+				},
+			],
+			types: {
+				string: ["name"],
+				boolean: ["u", "uppercase"],
+			},
+			//validate(args) {},
+			//help(args) {},
+			//allowUnknownOptions: true,
+			action(broker, args /*, helpers*/) {
+				let name = args.options.uppercase
+					? args.name.toUpperCase()
+					: args.name;
+				if (args.options.prefix) name = args.options.prefix + name;
+
+				return broker.call("greeter.hello", { name }).then(console.log);
+			},
+		},
+	],
+});
+
+broker.createService({
+	name: "greeter",
+	actions: {
+		hello: {
+			cache: true,
+			handler(ctx) {
+				return "Hello " + ctx.params.name;
+			},
+		},
+		welcome(ctx) {
+			return {
+				params: ctx.params,
+				welcomedAt: Date.now(),
+			};
+		},
+		silent(ctx) {
+			return;
+		},
+		echo(ctx) {
+			return {
+				params: ctx.params,
+				meta: ctx.meta,
+			};
+		},
+	},
+	events: {
+		"user.created"(ctx) {
+			this.logger.info(
+				"User created event received!",
+				ctx.params,
+				ctx.meta
+			);
+		},
+		"user.updated"(ctx) {
+			this.logger.info(
+				"User updated even received!",
+				ctx.params,
+				ctx.meta
+			);
+		},
+		"order.created": {
+			group: "order",
+			handler(payload) {
+				this.logger.info("User created even received!", payload);
+			},
+		},
+		"$local-event"(payload) {
+			this.logger.info("Local event received!", payload);
+		},
+	},
+});
+
+broker.createService({
+	name: "math",
+	actions: {
+		add: {
+			params: {
+				a: "number",
+				b: "number",
+			},
+			handler(ctx) {
+				return Number(ctx.params.a) + Number(ctx.params.b);
+			},
+		},
+	},
+});
+
+broker.createService({
+	name: "file",
+	actions: {
+		echo(ctx) {
+			return ctx.params;
+		},
+	},
+});
+
+broker.start().then(() =>
+	REPL(broker, {
+		delimiter: "moleculer λ",
+		customCommands: broker.options.replCommands,
+		tcpPort: 5001
+	})
+);

--- a/examples/remote/index.js
+++ b/examples/remote/index.js
@@ -8,7 +8,7 @@ const broker = new ServiceBroker({
 	nodeID: "repl-" + process.pid,
 
 	// REPL TCP Socket port
-	replTcpPort: 5001,
+	replTcpPort: 1337,
 
 	// Custom REPL command
 	replCommands: [
@@ -125,6 +125,6 @@ broker.start().then(() =>
 	REPL(broker, {
 		delimiter: "moleculer λ",
 		customCommands: broker.options.replCommands,
-		tcpPort: 5001
+		tcpPort: broker.options.replTcpPort
 	})
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moleculer-repl",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "moleculer-repl",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "clui": "^0.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,14 +1688,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001313",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
-      "integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==",
+      "version": "1.0.30001431",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -7130,9 +7136,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001313",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
-      "integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==",
+      "version": "1.0.30001431",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
       "dev": true
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moleculer-repl",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "REPL module for Moleculer",
   "main": "index.js",
   "scripts": {

--- a/types/src/index.d.ts
+++ b/types/src/index.d.ts
@@ -22,6 +22,10 @@ type REPLOptions = {
      * Custom commands
      */
     customCommands: Array<CustomCommand> | CustomCommand | null;
+    /**
+     * REPL TCP Port
+     */
+     tcpPort: number | null;
 };
 import nodeRepl = require("repl");
 type CommandOptions = {
@@ -82,5 +86,9 @@ declare module "moleculer" {
          * REPL delimiter
          */
         replDelimiter?: string;
+        /**
+         * REPL TCP Port
+         */
+        replTcpPort?: number;
     }
 }


### PR DESCRIPTION
- feature allows the possibility to connect to a REPL instance running on a remote machine over a TCP socket.  this allows one to connect to moleculer services running on remote machines over `telnet` or `socat`
- the implementation uses the approach described in https://nodejs.org/api/repl.html#starting-multiple-repl-instances-against-a-single-running-instance
- TCP socket port is configurable with the `tcpPort` REPL opts or with the `replTcpPort` broker configuration.
- this PR is simultaneous with the PR (#) in the `moleculer` project