### PR TITLE
allow to pass meta as JSON string

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,8 @@
 			"cwd": "${workspaceRoot}",
 			"args": [
 				"simple"
-			]
+			],
+			"console": "integratedTerminal"
 		},
 		{
 			"type": "node",

--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -122,6 +122,20 @@ async function handler(broker, args) {
 
 	const startTime = process.hrtime();
 	const nodeID = args.nodeID;
+
+	if (
+		nodeID &&
+		!broker.registry
+			.getServiceList({})
+			.map((service) => service.nodeID)
+			.includes(nodeID)
+	) {
+		console.error(
+			kleur.red().bold(`>> Node '${nodeID}' is not available.`)
+		);
+		return;
+	}
+
 	meta.$repl = true;
 	console.log(
 		kleur
@@ -228,7 +242,7 @@ function declaration(program, broker, cmdHandler) {
 		.allowExcessArguments(true)
 		.hook("preAction", (thisCommand) => {
 			const parsedOpts = thisCommand.parseOptions(thisCommand.args);
-			const [actionName, jsonParams] = parsedOpts.operands;
+			const [actionName, jsonParams, meta] = parsedOpts.operands;
 
 			let parsedArgs = {
 				...parser(parsedOpts.unknown), // Other params
@@ -243,6 +257,7 @@ function declaration(program, broker, cmdHandler) {
 				actionName,
 				nodeID: parsedArgs.$local ? broker.nodeID : undefined,
 				...(jsonParams !== undefined ? { jsonParams } : undefined),
+				...(meta !== undefined ? { meta } : undefined),
 				rawCommand,
 			};
 
@@ -269,7 +284,7 @@ function declaration(program, broker, cmdHandler) {
 		.allowExcessArguments(true)
 		.hook("preAction", (thisCommand) => {
 			const parsedOpts = thisCommand.parseOptions(thisCommand.args);
-			const [nodeID, actionName, jsonParams] = parsedOpts.operands;
+			const [nodeID, actionName, jsonParams, meta] = parsedOpts.operands;
 
 			let parsedArgs = {
 				...parser(parsedOpts.unknown), // Other params
@@ -284,6 +299,7 @@ function declaration(program, broker, cmdHandler) {
 				nodeID,
 				actionName,
 				...(jsonParams !== undefined ? { jsonParams } : undefined),
+				...(meta !== undefined ? { meta } : undefined),
 				rawCommand,
 			};
 

--- a/test/call.spec.js
+++ b/test/call.spec.js
@@ -120,7 +120,7 @@ describe("Test 'call' command", () => {
 	});
 
 	it("should call 'call' with JSON string parameter", async () => {
-		const command = `call "math.add" '{"a": 5, "b": "Bob", "c": true, "d": false, "e": { "f": "hello" } }'`;
+		const command = `call "math.add" '{"a": 5, "b": "Bob", "c": true, "d": false, "e": { "f": "hello" } }' '{"meta_a": 5, "meta_b": "Bob", "meta_c": true, "meta_d": false, "meta_e": { "meta_f": "hello" } }'`;
 
 		await program.parseAsync(
 			parseArgsStringToArgv(command, "node", "REPL")
@@ -132,7 +132,8 @@ describe("Test 'call' command", () => {
 			actionName: "math.add",
 			jsonParams:
 				'{"a": 5, "b": "Bob", "c": true, "d": false, "e": { "f": "hello" } }',
-			rawCommand: `call math.add {"a": 5, "b": "Bob", "c": true, "d": false, "e": { "f": "hello" } }`,
+			meta: '{"meta_a": 5, "meta_b": "Bob", "meta_c": true, "meta_d": false, "meta_e": { "meta_f": "hello" } }',
+			rawCommand: `call math.add {"a": 5, "b": "Bob", "c": true, "d": false, "e": { "f": "hello" } } {"meta_a": 5, "meta_b": "Bob", "meta_c": true, "meta_d": false, "meta_e": { "meta_f": "hello" } }`,
 		});
 	});
 
@@ -300,7 +301,7 @@ describe("Test 'dcall' command", () => {
 	});
 
 	it("should call 'dcall' with JSON string parameter", async () => {
-		const command = `dcall node123 "math.add" '{"a": 5, "b": "Bob", "c": true, "d": false, "e": { "f": "hello" } }'`;
+		const command = `dcall node123 "math.add" '{"a": 5, "b": "Bob", "c": true, "d": false, "e": { "f": "hello" } }' '{"meta_a": 5, "meta_b": "Bob", "meta_c": true, "meta_d": false, "meta_e": { "meta_f": "hello" } }'`;
 
 		await program.parseAsync(
 			parseArgsStringToArgv(command, "node", "REPL")
@@ -313,7 +314,8 @@ describe("Test 'dcall' command", () => {
 			nodeID: "node123",
 			jsonParams:
 				'{"a": 5, "b": "Bob", "c": true, "d": false, "e": { "f": "hello" } }',
-			rawCommand: `dcall node123 math.add {"a": 5, "b": "Bob", "c": true, "d": false, "e": { "f": "hello" } }`,
+			meta: '{"meta_a": 5, "meta_b": "Bob", "meta_c": true, "meta_d": false, "meta_e": { "meta_f": "hello" } }',
+			rawCommand: `dcall node123 math.add {"a": 5, "b": "Bob", "c": true, "d": false, "e": { "f": "hello" } } {"meta_a": 5, "meta_b": "Bob", "meta_c": true, "meta_d": false, "meta_e": { "meta_f": "hello" } }`,
 		});
 	});
 


### PR DESCRIPTION
Fixes #69 

Allows to pass meta as JSON encoded as string. For more info check the updates unit test.

Also, adds an additional check  that validates the `nodeID` in `dcall` command

```js
	if (
		nodeID &&
		!broker.registry
			.getServiceList({})
			.map((service) => service.nodeID)
			.includes(nodeID)
	) {
		console.error(
			kleur.red().bold(`>> Node '${nodeID}' is not available.`)
		);
		return;
	}
```

Examples: 
![image](https://github.com/moleculerjs/moleculer-repl/assets/9802754/616cd84f-d19f-4e00-9a98-195404dd36af)
